### PR TITLE
Feature1: Add ext stopgo handle for pause/resume without PS4 Debugging.

### DIFF
--- a/debugger/include/debug.h
+++ b/debugger/include/debug.h
@@ -138,6 +138,8 @@ struct debug_interrupt_packet {
 #define DEBUG_PORT 42069
 
 extern int g_debugging;
+extern int g_signal;
+extern uint32_t g_pid;
 extern struct server_client *curdbgcli;
 extern struct debug_context *curdbgctx;
 

--- a/debugger/include/protocol.h
+++ b/debugger/include/protocol.h
@@ -49,6 +49,7 @@
 #define CMD_DEBUG_STOPGO            0xBDBB0010
 #define CMD_DEBUG_THRINFO           0xBDBB0011
 #define CMD_DEBUG_SINGLESTEP        0xBDBB0012
+#define CMD_DEBUG_EXT_STOPGO        0xBDBB0500
 
 #define CMD_KERN_BASE               0xBDCC0001
 #define CMD_KERN_READ               0xBDCC0002
@@ -296,6 +297,12 @@ struct cmd_debug_thrinfo_response {
     char name[32];
     // TODO: add more information
 } __attribute__((packed));
+
+struct cmd_debug_ext_stopgo_packet {
+    uint32_t pid;
+    uint8_t stop;
+} __attribute__((packed));
+
 #define CMD_DEBUG_THRINFO_RESPONSE_SIZE 40
 
 #define MAX_BREAKPOINTS 30

--- a/debugger/source/server.c
+++ b/debugger/source/server.c
@@ -371,6 +371,7 @@ error:
 
 void configure_socket(int fd) {
     int flag;
+    int bufsize;
 
     flag = 1;
     sceNetSetsockopt(fd, SOL_SOCKET, SO_NBIO, (char *)&flag, sizeof(flag));
@@ -380,6 +381,18 @@ void configure_socket(int fd) {
 
     flag = 1;
     sceNetSetsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, (char *)&flag, sizeof(flag));
+
+    flag = 1;
+    sceNetSetsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, (char *)&flag, sizeof(flag));
+
+    flag = 1;
+    sceNetSetsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char *)&flag, sizeof(flag));
+
+    bufsize = 0x100000;
+    sceNetSetsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *)&bufsize, sizeof(bufsize));
+
+    bufsize = 0x100000;
+    sceNetSetsockopt(fd, SOL_SOCKET, SO_RCVBUF, (char *)&bufsize, sizeof(bufsize));
 }
 
 void *broadcast_thread(void *arg) {
@@ -495,6 +508,8 @@ int start_server() {
 
     // reset debugging stuff
     g_debugging = 0;
+    g_pid = 0;
+    g_signal = -1;
     curdbgcli = NULL;
     curdbgctx = NULL;
 


### PR DESCRIPTION
Uses the CMD_DEBUG_EXT_STOPGO command with cmd_debug_ext_stopgo_packet data. 
The stop field in the packet specifies the action: 0 (Resume), 1 (Pause), 2 (Stop). CMD_DEBUG_EXT_STOPGO (0xBDBB0500)

struct cmd_debug_ext_stopgo_packet {
    uint32_t pid;
    uint8_t stop;
} __attribute__((packed));

Feature2: Enhance socket configuration with keep-alive, reuseaddr, and larger buffers.

Tested and working well in 6.72 firmware.