### PR TITLE
Update debug_ext_stopgo_handle to use ptrace if the debugger has already been detached.

### DIFF
--- a/debugger/source/debug.c
+++ b/debugger/source/debug.c
@@ -614,6 +614,11 @@ int debug_ext_stopgo_handle(int fd, struct cmd_packet* packet) {
             sp->stop--;
             g_signal = sp->stop == 0 ? SIGSTOP : SIGKILL;
         }
+        r = ptrace(PT_CONTINUE, g_pid, (void*)1, g_signal);
+        if (r == -1 && errno) {
+            net_send_status(fd, CMD_ERROR);
+            return 1;
+        }
     }
 
     net_send_status(fd, CMD_SUCCESS);


### PR DESCRIPTION
I just realized I missed a part.

When the ps4 has already detached the debugger, ptrace should be used (same as debug_stopgo_handle).